### PR TITLE
feat(provider): add ability to override metadata permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,28 @@ export const enum PermissionKey {
   DeleteAudit = 'DeleteAudit',
 }
 ```
-- Serving the static files:
+- To Override the permissions provided in enum `permissionKey` file:
+
+  If the userPermission object is provided,it overrides the default permissions in the authorizationMetadata object.
+
+  For providing a userPermission object with custom permissions for specific controller methods, you can bind the following in `application.ts` file in your application.
+
+```ts
+
+this.bind(AuthorizationBindings.PERMISSION).to({
+   MessageController:{
+      create:['CreateMessage','ViewMessage'],
+      updateAll:['UpdateMessage','ViewMessage','ViewMessageNum]
+   }
+   AttachmentFileController:{
+      create:['CreateAttachmentFile','ViewAttachmentFile'],
+      updateAll:['UpdateAttachmentFile','ViewAttachmentFileNum']
+   }
+})
+
+```
+
+# Serving the static files:
 
 Authorization  configuration binding sets up paths that can be accessed without any authorization checks, allowing static files to be served directly  from the root URL of the application.The allowAlwaysPaths property is used to define these paths for the files in public directory  i.e for a test.html file in public directory ,one can provide its path as follows:
 

--- a/src/__tests__/unit/authorization-metadata.provider.unit.ts
+++ b/src/__tests__/unit/authorization-metadata.provider.unit.ts
@@ -1,0 +1,53 @@
+import {expect} from '@loopback/testlab';
+import {getAuthorizeMetadata} from '../../providers';
+import {AuthorizationMetadata, PermissionObject} from '../../types';
+import {authorize} from '../../decorators';
+import {get} from '@loopback/rest';
+
+describe('getAuthorizeMetadata()', function () {
+  it('should return the authorization metadata when userPermission is provided', () => {
+    class TestController {
+      @authorize({permissions: ['default1', 'default2']})
+      @get('/')
+      async testMethod() {
+        // This is intentional.
+      }
+    }
+    const methodName = 'testMethod';
+    const mockUserPermission: PermissionObject = {
+      TestController: {
+        testMethod: ['permission1', 'permission2'],
+      },
+    };
+
+    const authorizationMetadata = getAuthorizeMetadata(
+      TestController,
+      methodName,
+      mockUserPermission,
+    );
+    expect(authorizationMetadata?.permissions).which.eql(
+      mockUserPermission.TestController[methodName],
+    );
+  });
+
+  it('should return permissions from metadata if userpermission is not provided', () => {
+    class TestController {
+      @authorize({permissions: ['default1', 'default2']})
+      @get('/')
+      async testMethod() {
+        // This is intentional.
+      }
+    }
+    const methodName = 'testMethod';
+    const authorizationMetadata = getAuthorizeMetadata(
+      TestController,
+      methodName,
+    );
+    const expectedResult: AuthorizationMetadata = {
+      permissions: ['default1', 'default2'],
+    };
+    expect(authorizationMetadata?.permissions).which.eql(
+      expectedResult.permissions,
+    );
+  });
+});

--- a/src/component.ts
+++ b/src/component.ts
@@ -9,11 +9,13 @@ import {AuthorizationConfig} from './types';
 
 export class AuthorizationComponent implements Component {
   providers?: ProviderMap;
-  bindings?: Binding[];
+  bindings?: Binding[] = [];
 
   constructor(
     @inject(AuthorizationBindings.CONFIG)
     private readonly config?: AuthorizationConfig,
+    @inject(AuthorizationBindings.Permission, {optional: true})
+    private readonly permission?: unknown,
   ) {
     this.providers = {
       [AuthorizationBindings.AUTHORIZE_ACTION.key]: AuthorizeActionProvider,
@@ -22,24 +24,26 @@ export class AuthorizationComponent implements Component {
       [AuthorizationBindings.METADATA.key]: AuthorizationMetadataProvider,
       [AuthorizationBindings.USER_PERMISSIONS.key]: UserPermissionsProvider,
     };
-    this.bindings?.push(
-      Binding.bind(AuthorizationBindings.Permission).to(null),
-    );
+    if (!this.permission) {
+      this.bindings?.push(
+        Binding.bind(AuthorizationBindings.Permission).to(null),
+      );
+    }
     if (
       this.config?.allowAlwaysPaths &&
       this.config?.allowAlwaysPaths?.length > 0
     ) {
-      this.bindings = [
+      this.bindings?.push(
         Binding.bind(AuthorizationBindings.PATHS_TO_ALLOW_ALWAYS).to(
           this.config.allowAlwaysPaths,
         ),
-      ];
+      );
     } else {
-      this.bindings = [
+      this.bindings?.push(
         Binding.bind(AuthorizationBindings.PATHS_TO_ALLOW_ALWAYS).to([
           '/explorer',
         ]),
-      ];
+      );
     }
   }
 }

--- a/src/component.ts
+++ b/src/component.ts
@@ -14,7 +14,7 @@ export class AuthorizationComponent implements Component {
   constructor(
     @inject(AuthorizationBindings.CONFIG)
     private readonly config?: AuthorizationConfig,
-    @inject(AuthorizationBindings.Permission, {optional: true})
+    @inject(AuthorizationBindings.PERMISSION, {optional: true})
     private readonly permission?: unknown,
   ) {
     this.providers = {
@@ -26,7 +26,7 @@ export class AuthorizationComponent implements Component {
     };
     if (!this.permission) {
       this.bindings?.push(
-        Binding.bind(AuthorizationBindings.Permission).to(null),
+        Binding.bind(AuthorizationBindings.PERMISSION).to(null),
       );
     }
     if (

--- a/src/component.ts
+++ b/src/component.ts
@@ -22,7 +22,9 @@ export class AuthorizationComponent implements Component {
       [AuthorizationBindings.METADATA.key]: AuthorizationMetadataProvider,
       [AuthorizationBindings.USER_PERMISSIONS.key]: UserPermissionsProvider,
     };
-
+    this.bindings?.push(
+      Binding.bind(AuthorizationBindings.Permission).to(null),
+    );
     if (
       this.config?.allowAlwaysPaths &&
       this.config?.allowAlwaysPaths?.length > 0

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -8,6 +8,7 @@ import {
   CasbinAuthorizeFn,
   CasbinEnforcerConfigGetterFn,
   CasbinResourceModifierFn,
+  PermissionObject,
 } from './types';
 
 /**
@@ -16,6 +17,9 @@ import {
 export namespace AuthorizationBindings {
   export const AUTHORIZE_ACTION = BindingKey.create<AuthorizeFn>(
     'sf.userAuthorization.actions.authorize',
+  );
+  export const Permission = BindingKey.create<PermissionObject | null>(
+    `sf.userAuthorization.authorize.permissions`,
   );
 
   export const CASBIN_AUTHORIZE_ACTION = BindingKey.create<CasbinAuthorizeFn>(

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -18,7 +18,7 @@ export namespace AuthorizationBindings {
   export const AUTHORIZE_ACTION = BindingKey.create<AuthorizeFn>(
     'sf.userAuthorization.actions.authorize',
   );
-  export const Permission = BindingKey.create<PermissionObject | null>(
+  export const PERMISSION = BindingKey.create<PermissionObject | null>(
     `sf.userAuthorization.authorize.permissions`,
   );
 

--- a/src/providers/authorization-metadata.provider.ts
+++ b/src/providers/authorization-metadata.provider.ts
@@ -17,7 +17,7 @@ export class AuthorizationMetadataProvider
     private readonly controllerClass: Constructor<{}>,
     @inject(CoreBindings.CONTROLLER_METHOD_NAME, {optional: true})
     private readonly methodName: string,
-    @inject(AuthorizationBindings.Permission)
+    @inject(AuthorizationBindings.PERMISSION)
     private permissionObject: PermissionObject,
   ) {}
 

--- a/src/providers/authorization-metadata.provider.ts
+++ b/src/providers/authorization-metadata.provider.ts
@@ -36,17 +36,18 @@ export function getAuthorizeMetadata(
   methodName: string,
   userPermission?: PermissionObject,
 ): AuthorizationMetadata | undefined {
-  const value = MetadataInspector.getMethodMetadata<AuthorizationMetadata>(
-    AUTHORIZATION_METADATA_ACCESSOR,
-    controllerClass.prototype,
-    methodName,
-  ) ?? {permissions: []};
+  const authorizationMetadata =
+    MetadataInspector.getMethodMetadata<AuthorizationMetadata>(
+      AUTHORIZATION_METADATA_ACCESSOR,
+      controllerClass.prototype,
+      methodName,
+    ) ?? {permissions: []};
   if (userPermission) {
     const methodPermissions =
       userPermission?.[controllerClass.name]?.[methodName];
     if (methodPermissions) {
-      value.permissions = methodPermissions;
+      authorizationMetadata.permissions = methodPermissions;
     }
   }
-  return value;
+  return authorizationMetadata;
 }

--- a/src/providers/authorization-metadata.provider.ts
+++ b/src/providers/authorization-metadata.provider.ts
@@ -6,8 +6,8 @@ import {
 } from '@loopback/context';
 import {CoreBindings} from '@loopback/core';
 
-import {AUTHORIZATION_METADATA_ACCESSOR} from '../keys';
-import {AuthorizationMetadata} from '../types';
+import {AUTHORIZATION_METADATA_ACCESSOR, AuthorizationBindings} from '../keys';
+import {AuthorizationMetadata, PermissionObject} from '../types';
 
 export class AuthorizationMetadataProvider
   implements Provider<AuthorizationMetadata | undefined>
@@ -17,21 +17,36 @@ export class AuthorizationMetadataProvider
     private readonly controllerClass: Constructor<{}>,
     @inject(CoreBindings.CONTROLLER_METHOD_NAME, {optional: true})
     private readonly methodName: string,
+    @inject(AuthorizationBindings.Permission)
+    private permissionObject: PermissionObject,
   ) {}
 
   value(): AuthorizationMetadata | undefined {
     if (!this.controllerClass || !this.methodName) return;
-    return getAuthorizeMetadata(this.controllerClass, this.methodName);
+    return getAuthorizeMetadata(
+      this.controllerClass,
+      this.methodName,
+      this.permissionObject,
+    );
   }
 }
 
 export function getAuthorizeMetadata(
   controllerClass: Constructor<{}>,
   methodName: string,
+  userPermission?: PermissionObject,
 ): AuthorizationMetadata | undefined {
-  return MetadataInspector.getMethodMetadata<AuthorizationMetadata>(
+  const value = MetadataInspector.getMethodMetadata<AuthorizationMetadata>(
     AUTHORIZATION_METADATA_ACCESSOR,
     controllerClass.prototype,
     methodName,
-  );
+  ) ?? {permissions: []};
+  if (userPermission) {
+    const methodPermissions =
+      userPermission?.[controllerClass.name]?.[methodName];
+    if (methodPermissions) {
+      value.permissions = methodPermissions;
+    }
+  }
+  return value;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,11 @@ export interface CasbinAuthorizeFn {
     request: Request,
   ): Promise<boolean>;
 }
+export type PermissionObject = {
+  [controller: string]: {
+    [method: string]: string[];
+  };
+};
 /**
  * Authorization metadata interface for the method decorator
  */


### PR DESCRIPTION
add ability to override metadata permissions with the permission object passed by the user.

GH-95

## Description

add ability to override metadata permissions with the permission object passed by the user.

Fixes #95 
See: https://github.com/sourcefuse/loopback4-microservice-catalog/issues/1381

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Intermediate change (work in progress)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] Performed a self-review of my own code
- [ ] npm test passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the style guide
- [ ] API Documentation in code was updated
- [ ] Any dependent changes have been merged and published in downstream modules
