### PR TITLE
fix(provider): reverting gh 155

### DIFF
--- a/src/decorators/authorize.decorator.ts
+++ b/src/decorators/authorize.decorator.ts
@@ -40,9 +40,8 @@ export function authorize(metadata: AuthorizationMetadata) {
       meta.spec = specPreprocessor(target, propertyKey, metadata, meta.spec);
       Reflector.deleteMetadata(OAI3KEY_METHODS, target, propertyKey);
       Reflector.defineMetadata(OAI3KEY_METHODS, meta, target, propertyKey);
+      authorizedecorator(target, propertyKey, descriptor);
     }
-    // authorization should work even if no method metadata is present
-    authorizedecorator(target, propertyKey, descriptor);
   };
 
   return authorizationWithMetadata;


### PR DESCRIPTION
authorize decorator to be used inside method metadata

GH-155

## Description

reverting changes done in c8aedb6881b5f53a632b89ae4a1b62fee19e322b

https://github.com/sourcefuse/loopback4-authorization/commit/c8aedb6881b5f53a632b89ae4a1b62fee19e322b

Fixes #155

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Intermediate change (work in progress)

## Checklist:

- [ ] Performed a self-review of my own code
- [ ] npm test passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the style guide
- [ ] API Documentation in code was updated
- [ ] Any dependent changes have been merged and published in downstream modules
